### PR TITLE
Works on Windows but needs Mac testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "typescript": "^3.8.3"
   },
   "scripts": {
-    "phone": "REACT_APP_API_ROOT=http://192.168.1.10:8000 REACT_APP_SOCKET_ROOT=http://192.168.1.10:8000 react-scripts start",
-    "dev": "REACT_APP_API_ROOT=http://localhost:8000 REACT_APP_SOCKET_ROOT=http://localhost:8000 react-scripts start",
-    "repl": "ts-node --files --project ./tsconfig.json -O '{\"module\": \"commonjs\"}'",
-    "server": "ts-node --files --project ./tsconfig.json -O '{\"module\": \"commonjs\"}' ./src/server/index.ts",
+    "phone": "env REACT_APP_API_ROOT=http://192.168.1.10:8000 REACT_APP_SOCKET_ROOT=http://192.168.1.10:8000 react-scripts start",
+    "dev": "env REACT_APP_API_ROOT=http://localhost:8000 REACT_APP_SOCKET_ROOT=http://localhost:8000 react-scripts start",
+    "repl": "env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' ts-node --files --project ./tsconfig.json npm",
+    "server": "env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' ts-node --files --project ./tsconfig.json ./src/server/index.ts",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
This should effectively be the same but plz test on Mac and make sure the commands still work. 
Setting TS_NODE_COMPILER_OPTIONS and -O should be equivalent, see docs:
https://www.npmjs.com/package/ts-node
