### PR TITLE
Tiles stop jumping when you click, shuffle order saved

### DIFF
--- a/src/game/rabble.ts
+++ b/src/game/rabble.ts
@@ -19,7 +19,6 @@ import {
   allSquaresInWord,
 } from "./play";
 import { checkForInvalidWords, scoreForValidWords } from "./score";
-import { PlayerID } from "boardgame.io";
 
 const prefixed = (logPrefixFunction: any, original: any) =>
   function () {
@@ -228,6 +227,14 @@ const Rabble = (wordlist: WordList) => ({
         if (G.scoreList) {
           G.scoreList[currentPlayer].nickname = nickname;
         }
+      },
+      client: true,
+    },
+    reorderRackTiles: {
+      move: (G: Game, ctx: GameContext, rackTiles: Tile[]) => {
+        const { currentPlayer } = ctx;
+        const { currentPlay } = G.players[currentPlayer];
+        G.players[currentPlayer].tileRack = [...rackTiles];
       },
       client: true,
     },

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -68,6 +68,7 @@ type GameBoardProps = {
     checkWord: (playSquares: Square[]) => void;
     cleanUp: () => void;
     setNickName: (nickname: string) => void;
+    reorderRackTiles: (rackTiles: Tile[]) => void;
   };
   events: {
     endTurn: any;

--- a/src/webapp/features/rabble/Buttons.tsx
+++ b/src/webapp/features/rabble/Buttons.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import styles from "./Buttons.module.css";
 import { useSelector, useDispatch } from "react-redux";
 import { shuffleRack, updateRackTiles } from "./rackSlice";
+import { shuffleTiles } from "../../../game/tileBag";
 import {
   clearPlayTiles,
   changeSquareSelection,
@@ -27,6 +28,7 @@ type ButtonsProps = {
   currentPlayTilesLaid: Tile[];
   currentPlay: any;
   setErrorMessage: (message: string) => void;
+  reorderRackTiles: (rackTiles: Tile[]) => void;
 };
 
 const Buttons = ({
@@ -41,6 +43,7 @@ const Buttons = ({
   currentPlayTilesLaid,
   currentPlay,
   setErrorMessage,
+  reorderRackTiles,
 }: ButtonsProps) => {
   const dispatch = useDispatch();
 
@@ -119,7 +122,10 @@ const Buttons = ({
       )}
       <button
         onClick={() => {
-          dispatch(shuffleRack());
+          shuffleTiles(tileRack);
+          reorderRackTiles(tileRack);
+          dispatch(clearPlayTiles());
+          dispatch(changeSquareSelection(null));
         }}
       >
         <ShuffleIcon />
@@ -129,11 +135,13 @@ const Buttons = ({
       {currentPlayerHasTurn && (
         <button
           onClick={() => {
-            dispatch(clearPlayTiles());
-            exchangeTiles(playTilesFromSquares(playSquares));
-            dispatch(changeSquareSelection(null));
-            setPlayed(true);
-            cleanUp();
+            if (playSquares.length > 0) {
+              dispatch(clearPlayTiles());
+              exchangeTiles(playTilesFromSquares(playSquares));
+              dispatch(changeSquareSelection(null));
+              setPlayed(true);
+              cleanUp();
+            }
           }}
         >
           <SwapIcon />

--- a/src/webapp/features/rabble/GameControls.tsx
+++ b/src/webapp/features/rabble/GameControls.tsx
@@ -21,7 +21,14 @@ const GameControls = (props: GameBoardProps) => {
     playerID,
     ctx: { currentPlayer, gameover },
     G: { players, gameBoard },
-    moves: { playWord, exchangeTiles, checkWord, cleanUp, setNickName },
+    moves: {
+      playWord,
+      exchangeTiles,
+      checkWord,
+      cleanUp,
+      setNickName,
+      reorderRackTiles,
+    },
     events: { endTurn },
   } = props;
 
@@ -61,13 +68,13 @@ const GameControls = (props: GameBoardProps) => {
       <h4>
         <div className={styles.invalidPlayError}>{errorMessage}</div>
         <TileRack
-          onTileClick={(tile) => {
+          onTileClick={(tile): boolean => {
             if (canAddOneMoreTile) {
               const copyRack = [...displayTileRack];
 
               if (tile.blank) {
                 setShowModal(true);
-                return;
+                return true;
               }
 
               pullPlayTilesFromRack([tile], copyRack);
@@ -79,9 +86,13 @@ const GameControls = (props: GameBoardProps) => {
               dispatch(updateRackTiles(copyRack));
 
               setErrorMessage("");
+
+              return true;
             }
+            return false;
           }}
-          tileRack={displayTileRack}
+          tilesInRack={displayTileRack}
+          playerTiles={tileRack}
         />
         <Buttons
           currentPlayIsValid={currentPlayIsValid}
@@ -92,6 +103,7 @@ const GameControls = (props: GameBoardProps) => {
           endTurn={endTurn}
           tileRack={tileRack}
           cleanUp={cleanUp}
+          reorderRackTiles={reorderRackTiles}
           currentPlayTilesLaid={currentPlayTilesLaid}
           currentPlay={currentPlay}
           setErrorMessage={setErrorMessage}

--- a/src/webapp/features/rabble/boardSlice.ts
+++ b/src/webapp/features/rabble/boardSlice.ts
@@ -100,6 +100,7 @@ export const slice = createSlice({
         state.selectedLocation = null;
         state.direction = null;
         state.playableLocations = [];
+
         return;
       }
 

--- a/src/webapp/features/rabble/boardSlice.ts
+++ b/src/webapp/features/rabble/boardSlice.ts
@@ -100,7 +100,6 @@ export const slice = createSlice({
         state.selectedLocation = null;
         state.direction = null;
         state.playableLocations = [];
-
         return;
       }
 

--- a/src/webapp/features/rabble/components/TileRack.tsx
+++ b/src/webapp/features/rabble/components/TileRack.tsx
@@ -10,13 +10,14 @@ type TileRackProps = {
 
 const TileRack = ({ tilesInRack, playerTiles, onTileClick }: TileRackProps) => {
   const [clickedTiles, setClickedTiles] = useState([] as number[]);
-
+  // If the player put their tiles back, clear the clicked tiles
   useEffect(() => {
     if (playerTiles.length === tilesInRack.length) {
       setClickedTiles([]);
     }
   }, [playerTiles, tilesInRack]);
 
+  // Insert blank spaces in the rack for already clicked tiles
   const renderTiles = playerTiles.map((t, idx) =>
     clickedTiles.includes(idx) ? null : t
   );
@@ -28,7 +29,9 @@ const TileRack = ({ tilesInRack, playerTiles, onTileClick }: TileRackProps) => {
           {tileOrNull ? (
             <Tile
               onClick={(ev) => {
+                // if the click put the tile on the board
                 if (onTileClick(ev)) {
+                  // save which position the tile was in, and show a blank space there
                   setClickedTiles([...clickedTiles, idx]);
                 }
               }}

--- a/src/webapp/features/rabble/components/TileRack.tsx
+++ b/src/webapp/features/rabble/components/TileRack.tsx
@@ -1,18 +1,40 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./TileRack.module.css";
 import Tile from "./Tile";
 
 type TileRackProps = {
-  tileRack: Tile[];
-  onTileClick: (tile: Tile) => void;
+  tilesInRack: Tile[];
+  playerTiles: Tile[];
+  onTileClick: (tile: Tile) => boolean;
 };
 
-const TileRack = ({ tileRack, onTileClick }: TileRackProps) => {
+const TileRack = ({ tilesInRack, playerTiles, onTileClick }: TileRackProps) => {
+  const [clickedTiles, setClickedTiles] = useState([] as number[]);
+
+  useEffect(() => {
+    if (playerTiles.length === tilesInRack.length) {
+      setClickedTiles([]);
+    }
+  }, [playerTiles, tilesInRack]);
+
+  const renderTiles = playerTiles.map((t, idx) =>
+    clickedTiles.includes(idx) ? null : t
+  );
+
   return (
     <div className={styles.tileRack}>
-      {tileRack.map((t, idx) => (
+      {renderTiles.map((tileOrNull, idx) => (
         <div key={idx} className={styles.tileContainer}>
-          <Tile onClick={onTileClick} tile={t} />
+          {tileOrNull ? (
+            <Tile
+              onClick={(ev) => {
+                if (onTileClick(ev)) {
+                  setClickedTiles([...clickedTiles, idx]);
+                }
+              }}
+              tile={tileOrNull}
+            />
+          ) : null}
         </div>
       ))}
     </div>


### PR DESCRIPTION
We should also consider adding stages to the turn order logic so that players who are not playing their turn can shuffle their tiles and save the shuffled order to the server.