### PR TITLE
Swap tiles bugfixes and modal + modal style updates

### DIFF
--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -1,6 +1,6 @@
 ## TODO
 
-- Exchange modal
+- Modals should either disable the board, or disappear when board clicked
 
 - SQLify the sqlite adapter (e.g. logs as separate records)
 - sqlite3 models also can provide some more sugar to make managing documents easier

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -1,7 +1,5 @@
 ## TODO
 
-- Modals should either disable the board, or disappear when board clicked
-
 - SQLify the sqlite adapter (e.g. logs as separate records)
 - sqlite3 models also can provide some more sugar to make managing documents easier
 - Some sort of script that on deploy will take old games and archive them to separate DB

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -1,11 +1,14 @@
 ## TODO
 
-- Run checkword and score calculation debounced when letter placed.
+- SQLify the sqlite adapter (e.g. logs as separate records)
+- sqlite3 models also can provide some more sugar to make managing documents easier
+- Some sort of script that on deploy will take old games and archive them to separate DB
+
+- Recent games list uses a table for display, has a "remove" button for single games
 
 - Add stages to gameplay so that players can make shuffle moves outside of their turn
 
 - Unbork production stack traces somehow
-
 - Add a favicon and remove create react app branding
 
 - Add an integration test that checks all the turns plus the racks against the config

--- a/docs/NOTES.md
+++ b/docs/NOTES.md
@@ -1,5 +1,7 @@
 ## TODO
 
+- Exchange modal
+
 - SQLify the sqlite adapter (e.g. logs as separate records)
 - sqlite3 models also can provide some more sugar to make managing documents easier
 - Some sort of script that on deploy will take old games and archive them to separate DB

--- a/docs/milestone-03.md
+++ b/docs/milestone-03.md
@@ -8,10 +8,10 @@
 - Tap rack tiles to play horizontally or vertically instead of keyboard ✅
 - Dictionary check happens after tiles are laid, then allows you to play ✅
 
-- Show score during play ✔ (...on the board!)
+- Exchange tiles pops a modal, tap tiles to select which to exchange ✅
+- Blank chooser modal V2 needs a nicer UX ✅
 
-- Exchange tiles pops a modal, tap tiles to select which to exchange
-- Blank chooser modal V2 needs a nicer UX
+- Show score during play ✔ (...on the board!)
 
 - Drag rack tiles to reorder them
 - Drag rack tiles to place them on the board

--- a/docs/milestone-03.md
+++ b/docs/milestone-03.md
@@ -4,18 +4,18 @@
 
 #### Gameplay
 
-- Show score during play (on the board)
-- Dictionary check happens after tiles are laid, then allows you to play
+- Shuffled rack order preserved on server ✅
+- Tap rack tiles to play horizontally or vertically instead of keyboard ✅
+- Dictionary check happens after tiles are laid, then allows you to play ✅
+
+- Show score during play ✔ (...on the board!)
 
 - Exchange tiles pops a modal, tap tiles to select which to exchange
 - Blank chooser modal V2 needs a nicer UX
 
-- Tap rack tiles to play horizontally or vertically instead of keyboard ✅
 - Drag rack tiles to reorder them
 - Drag rack tiles to place them on the board
 - Drag placed tiles on the board to re-place them
-
-- Shuffled rack order preserved on server ✅
 
 #### Lobby
 
@@ -29,6 +29,6 @@
 
 - debug / recover "unexpected state error"
 
-- Better state abstraction (and name) for "word you are about to play"
+- Better state abstraction (and name) for "word you are about to play" ✅
 
 - Tests for Rabble game file

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typescript": "^3.8.3"
   },
   "scripts": {
-    "phone": "env REACT_APP_API_ROOT=http://192.168.0.3:8000 REACT_APP_SOCKET_ROOT=http://192.168.0.3:8000 react-scripts start",
+    "phone": "env REACT_APP_API_ROOT=http://192.168.1.5:8000 REACT_APP_SOCKET_ROOT=http://192.168.1.5:8000 react-scripts start",
     "dev": "env REACT_APP_API_ROOT=http://localhost:8000 REACT_APP_SOCKET_ROOT=http://localhost:8000 react-scripts start",
     "repl": "env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' ts-node --files --project ./tsconfig.json",
     "server": "env TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' ts-node --files --project ./tsconfig.json ./src/server/index.ts",

--- a/src/game/rabble.ts
+++ b/src/game/rabble.ts
@@ -265,6 +265,9 @@ const Rabble = (wordlist: WordList) => ({
         };
         G.turns.push(thisTurn);
         G.turnsReverse = [...G.turns].reverse();
+        G.players[currentPlayer].currentPlay = currentPlayInfo({
+          played: true,
+        });
       },
       client: false,
     },

--- a/src/game/rabble.ts
+++ b/src/game/rabble.ts
@@ -248,6 +248,11 @@ const Rabble = (wordlist: WordList) => ({
           return INVALID_MOVE;
         }
 
+        console.log(
+          "EXCHANGE TILES",
+          exchange.map((t) => t.letter)
+        );
+
         logMetaData.pid = currentPlayer;
         try {
           exchangeTiles(tileBag, tileRack, exchange);

--- a/src/game/tileBag.ts
+++ b/src/game/tileBag.ts
@@ -16,7 +16,7 @@ export const tilesFromString = (word: string): Tile[] => {
 };
 
 export const tileBagConfig: TileBagConfig = {
-  " ": { letter: " ", value: 0, blank: true, frequency: 2 },
+  " ": { letter: " ", value: 0, blank: true, frequency: 100 },
   A: { letter: "A", value: 1, blank: false, frequency: 9 },
   B: { letter: "B", value: 3, blank: false, frequency: 2 },
   C: { letter: "C", value: 3, blank: false, frequency: 2 },

--- a/src/game/tileBag.ts
+++ b/src/game/tileBag.ts
@@ -16,7 +16,7 @@ export const tilesFromString = (word: string): Tile[] => {
 };
 
 export const tileBagConfig: TileBagConfig = {
-  " ": { letter: " ", value: 0, blank: true, frequency: 100 },
+  " ": { letter: " ", value: 0, blank: true, frequency: 2 },
   A: { letter: "A", value: 1, blank: false, frequency: 9 },
   B: { letter: "B", value: 3, blank: false, frequency: 2 },
   C: { letter: "C", value: 3, blank: false, frequency: 2 },

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -32,7 +32,7 @@ loadWordList(process.env.WORDLIST_PATH || "").then((wordlist) => {
     db: new Sqlite3Store({
       filename: `${process.env.FLATFILE_PATH}/rabble.db`,
       logging: false,
-      debug: true,
+      debug: false,
     }),
   });
 

--- a/src/webapp/features/rabble/Buttons.module.css
+++ b/src/webapp/features/rabble/Buttons.module.css
@@ -18,6 +18,3 @@
   width: 24px;
   height: 24px;
 }
-
-.play {
-}

--- a/src/webapp/features/rabble/Buttons.tsx
+++ b/src/webapp/features/rabble/Buttons.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./Buttons.module.css";
 import { useSelector, useDispatch } from "react-redux";
 import { updateRackTiles } from "./rackSlice";
@@ -8,7 +8,9 @@ import {
   changeSquareSelection,
   selectPlaySquares,
 } from "./boardSlice";
-import { playTilesFromSquares } from "../../../game/play";
+
+import SwapTiles from "./components/SwapTiles";
+import Modal from "./components/Modal";
 
 import { ReactComponent as ShuffleIcon } from "./svg/shuffle-outline.svg";
 import { ReactComponent as UndoIcon } from "./svg/arrow-undo-outline.svg";
@@ -21,24 +23,26 @@ type ButtonsProps = {
   tileRack: Tile[];
   playWord: (playSquares: Square[]) => void;
   checkWord: (playSquares: Square[]) => void;
-  exchangeTiles: (playTiles: Tile[]) => void;
   endTurn: () => {};
   cleanUp: () => void;
+  exchangeTiles: (tiles: Tile[]) => void;
   currentPlay: CurrentPlayInfo;
   reorderRackTiles: (rackTiles: Tile[]) => void;
 };
 
 const Buttons = ({
   currentPlayerHasTurn,
-  exchangeTiles,
   playWord,
   endTurn,
   cleanUp,
+  exchangeTiles,
   tileRack,
   currentPlay,
   reorderRackTiles,
 }: ButtonsProps) => {
   const dispatch = useDispatch();
+
+  const [showSwapModal, setShowSwapModal] = useState(false);
 
   const playSquares = useSelector(selectPlaySquares);
   // end turn when played is true
@@ -103,19 +107,24 @@ const Buttons = ({
       {currentPlayerHasTurn && (
         <button
           onClick={() => {
-            if (playSquares.length > 0) {
-              dispatch(clearPlayTiles());
-              exchangeTiles(playTilesFromSquares(playSquares));
-              dispatch(changeSquareSelection(null));
-              cleanUp();
-              endTurn();
-            }
+            dispatch(clearPlayTiles());
+            dispatch(changeSquareSelection(null));
+            setShowSwapModal(true);
           }}
         >
           <SwapIcon />
           SWAP
         </button>
       )}
+      <Modal showModal={showSwapModal}>
+        <SwapTiles
+          setShowModal={setShowSwapModal}
+          tileRack={tileRack}
+          swapSelectedTiles={(tiles) => {
+            exchangeTiles(tiles);
+          }}
+        />
+      </Modal>
     </div>
   );
 };

--- a/src/webapp/features/rabble/Buttons.tsx
+++ b/src/webapp/features/rabble/Buttons.tsx
@@ -118,8 +118,9 @@ const Buttons = ({
       )}
       <Modal showModal={showSwapModal}>
         <SwapTiles
+          showModal={showSwapModal}
           setShowModal={setShowSwapModal}
-          tileRack={tileRack}
+          playerTiles={tileRack}
           swapSelectedTiles={(tiles) => {
             exchangeTiles(tiles);
           }}

--- a/src/webapp/features/rabble/components/ChooseBlank.module.css
+++ b/src/webapp/features/rabble/components/ChooseBlank.module.css
@@ -1,7 +1,13 @@
-.chooseBlank {
+.chooseBlankModal {
+  padding: 30px;
+}
+
+.chooseBlankHeader {
+  margin-bottom: 10px;
+}
+
+.tilesContainer {
   height: auto;
-  max-width: 400px;
-  width: 60vw;
   display: flex;
   flex-wrap: wrap;
   margin-left: auto;

--- a/src/webapp/features/rabble/components/ChooseBlank.tsx
+++ b/src/webapp/features/rabble/components/ChooseBlank.tsx
@@ -9,16 +9,21 @@ type ChooseBlankProps = {
 
 const ChooseBlank = ({ selectTile }: ChooseBlankProps) => {
   return (
-    <div className={styles.chooseBlank}>
-      {alphabetTiles.map((t, idx) => (
-        <div
-          key={idx}
-          className={styles.tileWrapper}
-          onClick={(ev) => selectTile(t)}
-        >
-          <Tile onClick={() => {}} tile={t} />
-        </div>
-      ))}
+    <div className={styles.chooseBlankModal}>
+      <div className={styles.chooseBlankHeader}>
+        <strong>Choose Any Letter</strong>
+      </div>
+      <div className={styles.tilesContainer}>
+        {alphabetTiles.map((t, idx) => (
+          <div
+            key={idx}
+            className={styles.tileWrapper}
+            onClick={(ev) => selectTile(t)}
+          >
+            <Tile onClick={() => {}} tile={t} />
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/src/webapp/features/rabble/components/Modal.module.css
+++ b/src/webapp/features/rabble/components/Modal.module.css
@@ -18,3 +18,13 @@
     width: 390px;
   }
 }
+
+.overlay {
+  position: fixed;
+  z-index: 400;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(128, 128, 128, 0.5);
+}

--- a/src/webapp/features/rabble/components/Modal.module.css
+++ b/src/webapp/features/rabble/components/Modal.module.css
@@ -1,20 +1,20 @@
 .Modal {
   position: fixed;
   z-index: 500;
-  background-color: white;
-  width: 70%;
+  width: 100%;
   border: 1px solid #ccc;
   box-shadow: 1px 1px 1px black;
-  padding: 16px;
-  left: 15%;
-  bottom: 6%;
+  margin: 0 auto;
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%);
   box-sizing: border-box;
   transition: all 0.3s ease-out;
+  background-color: var(--bg);
 }
 
 @media (min-width: 600px) {
   .Modal {
-    width: 500px;
-    left: calc(50% - 250px);
+    width: 390px;
   }
 }

--- a/src/webapp/features/rabble/components/Modal.tsx
+++ b/src/webapp/features/rabble/components/Modal.tsx
@@ -11,9 +11,11 @@ const Modal = (props: Props) => {
   const showModalStyle = { display: props.showModal ? undefined : "none" };
   const toggle = props.toggle;
   return (
-    <div className={styles.Modal} style={showModalStyle}>
-      {toggle && <button onClick={(ev) => toggle()}>X</button>}
-      {props.children}
+    <div className={styles.overlay} style={showModalStyle}>
+      <div className={styles.Modal} style={showModalStyle}>
+        {toggle && <button onClick={(ev) => toggle()}>X</button>}
+        {props.children}
+      </div>
     </div>
   );
 };

--- a/src/webapp/features/rabble/components/SwapTiles.module.css
+++ b/src/webapp/features/rabble/components/SwapTiles.module.css
@@ -4,10 +4,22 @@
   margin: 10px auto;
 }
 
+.swapTilesHeader {
+  margin-bottom: 10px;
+}
+
 .topRow {
   display: flex;
   width: 100%;
+  max-width: 360px;
+  margin: 0 auto;
   justify-content: space-between;
+}
+
+@media (max-width: 400px) {
+  .topRow {
+    max-width: 360px;
+  }
 }
 
 .topRow > button {

--- a/src/webapp/features/rabble/components/SwapTiles.module.css
+++ b/src/webapp/features/rabble/components/SwapTiles.module.css
@@ -1,36 +1,44 @@
-.swapTiles {
+.swapTilesModal {
   height: auto;
-  max-width: 400px;
-  width: 60vw;
+  padding: 5px;
+  margin: 10px auto;
+}
+
+.topRow {
   display: flex;
-  flex-wrap: wrap;
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
+  justify-content: space-between;
+}
+
+.topRow > button {
+  padding: 0px;
+  width: 45px;
+  height: 45px;
+  font-size: x-small;
+}
+
+.topRow > button > svg {
+  width: 16px;
+  height: 16px;
 }
 
 .swapRack {
-  height: 50px;
+  height: 45px;
   display: flex;
   align-items: center;
   justify-content: center;
   font-family: "Lato", sans-serif;
+  margin-bottom: 10px;
 }
 
-.swapContainer {
-  height: 50px;
-  width: 50px;
+.swapTileContainer {
+  height: 25px;
+  width: 25px;
   padding: 1px;
   display: inline-block;
   position: relative;
 }
 
-button > svg {
-  width: 24px;
-  height: 24px;
-}
-
-.topButtons {
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
+.rackContainer {
+  margin: 0 auto;
 }

--- a/src/webapp/features/rabble/components/SwapTiles.module.css
+++ b/src/webapp/features/rabble/components/SwapTiles.module.css
@@ -1,0 +1,36 @@
+.swapTiles {
+  height: auto;
+  max-width: 400px;
+  width: 60vw;
+  display: flex;
+  flex-wrap: wrap;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.swapRack {
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "Lato", sans-serif;
+}
+
+.swapContainer {
+  height: 50px;
+  width: 50px;
+  padding: 1px;
+  display: inline-block;
+  position: relative;
+}
+
+button > svg {
+  width: 24px;
+  height: 24px;
+}
+
+.topButtons {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+}

--- a/src/webapp/features/rabble/components/SwapTiles.tsx
+++ b/src/webapp/features/rabble/components/SwapTiles.tsx
@@ -62,6 +62,9 @@ const SwapTiles = ({
 
   return (
     <div className={styles.swapTilesModal}>
+      <div className={styles.swapTilesHeader}>
+        <strong>Swap some letters?</strong>
+      </div>
       <div className={styles.topRow}>
         <button onClick={cancelSwap}>
           <UndoIcon /> NOPE

--- a/src/webapp/features/rabble/components/SwapTiles.tsx
+++ b/src/webapp/features/rabble/components/SwapTiles.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from "react";
+import styles from "./SwapTiles.module.css";
+import Tile from "./Tile";
+import TileRack from "./TileRack";
+import { pullPlayTilesFromRack } from "../../../../game/tileBag";
+
+import { ReactComponent as UndoIcon } from "../svg/arrow-undo-outline.svg";
+import { ReactComponent as SwapIcon } from "../svg/swap-horizontal-outline.svg";
+
+type SwapTilesProps = {
+  setShowModal: (show: boolean) => void;
+  tileRack: Tile[];
+  swapSelectedTiles: (tiles: Tile[]) => void;
+};
+
+const SwapTiles = ({
+  tileRack,
+  setShowModal,
+  swapSelectedTiles,
+}: SwapTilesProps) => {
+  const [tilesToSwap, setTilesToSwap] = useState([] as Tile[]);
+  const [tilesInRack, setTilesInRack] = useState(tileRack);
+
+  const sendTileToSwap = (tile: Tile) => {
+    const copyRack = [...tilesInRack];
+    pullPlayTilesFromRack([tile], copyRack);
+    setTilesInRack(copyRack);
+    setTilesToSwap([...tilesToSwap, tile]);
+    return true;
+  };
+
+  const cleanup = () => {
+    setTilesToSwap([]);
+    setTilesInRack(tileRack);
+  };
+
+  const cancelSwap = () => {
+    cleanup();
+    setShowModal(false);
+  };
+
+  const swapTiles = () => {
+    swapSelectedTiles(tilesToSwap);
+    cleanup();
+    setShowModal(false);
+  };
+
+  return (
+    <div className={styles.swapTiles}>
+      <div className={styles.topButtons}>
+        <button onClick={cancelSwap}>
+          <UndoIcon />
+          CANCEL
+        </button>
+        <button disabled={tilesToSwap.length === 0} onClick={swapTiles}>
+          <SwapIcon />
+          SWAP
+        </button>
+      </div>
+      <div className={styles.swapRack}>
+        {tilesToSwap.map((tile, idx) => (
+          <div key={idx} className={styles.swapContainer}>
+            <Tile
+              onClick={(ev) => {
+                console.log("swap tile click", idx);
+              }}
+              tile={tile}
+            />
+          </div>
+        ))}
+      </div>
+      <TileRack
+        onTileClick={sendTileToSwap}
+        tilesInRack={tilesInRack}
+        playerTiles={tileRack}
+      />
+    </div>
+  );
+};
+
+export default SwapTiles;

--- a/src/webapp/features/rabble/components/SwapTiles.tsx
+++ b/src/webapp/features/rabble/components/SwapTiles.tsx
@@ -61,34 +61,35 @@ const SwapTiles = ({
   };
 
   return (
-    <div className={styles.swapTiles}>
-      <div className={styles.topButtons}>
+    <div className={styles.swapTilesModal}>
+      <div className={styles.topRow}>
         <button onClick={cancelSwap}>
-          <UndoIcon />
-          CANCEL
+          <UndoIcon /> NOPE
         </button>
+        <div className={styles.swapRack}>
+          {tilesToSwap.map((tile, idx) => (
+            <div key={idx} className={styles.swapTileContainer}>
+              <Tile
+                onClick={(ev) => {
+                  console.log("swap tile click", idx);
+                }}
+                tile={tile}
+                context="board"
+              />
+            </div>
+          ))}
+        </div>
         <button disabled={tilesToSwap.length === 0} onClick={swapTiles}>
-          <SwapIcon />
-          SWAP
+          <SwapIcon /> SWAP
         </button>
       </div>
-      <div className={styles.swapRack}>
-        {tilesToSwap.map((tile, idx) => (
-          <div key={idx} className={styles.swapContainer}>
-            <Tile
-              onClick={(ev) => {
-                console.log("swap tile click", idx);
-              }}
-              tile={tile}
-            />
-          </div>
-        ))}
+      <div className={styles.rackContainer}>
+        <TileRack
+          onTileClick={sendTileToSwap}
+          tilesInRack={tilesInRack}
+          playerTiles={playerTiles}
+        />
       </div>
-      <TileRack
-        onTileClick={sendTileToSwap}
-        tilesInRack={tilesInRack}
-        playerTiles={playerTiles}
-      />
     </div>
   );
 };

--- a/src/webapp/features/rabble/components/SwapTiles.tsx
+++ b/src/webapp/features/rabble/components/SwapTiles.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import styles from "./SwapTiles.module.css";
 import Tile from "./Tile";
 import TileRack from "./TileRack";
@@ -8,22 +8,37 @@ import { ReactComponent as UndoIcon } from "../svg/arrow-undo-outline.svg";
 import { ReactComponent as SwapIcon } from "../svg/swap-horizontal-outline.svg";
 
 type SwapTilesProps = {
+  showModal: boolean;
+  playerTiles: Tile[];
   setShowModal: (show: boolean) => void;
-  tileRack: Tile[];
   swapSelectedTiles: (tiles: Tile[]) => void;
 };
 
 const SwapTiles = ({
-  tileRack,
+  showModal,
+  playerTiles,
   setShowModal,
   swapSelectedTiles,
 }: SwapTilesProps) => {
   const [tilesToSwap, setTilesToSwap] = useState([] as Tile[]);
-  const [tilesInRack, setTilesInRack] = useState(tileRack);
+  const [tilesInRack, setTilesInRack] = useState(playerTiles);
+
+  // the modal stays rendered when it's not shown
+  // reset the rack tiles when showModal changes to prevent a stale rack
+  useEffect(() => {
+    if (showModal) {
+      setTilesInRack(playerTiles);
+    }
+  }, [showModal, playerTiles]);
 
   const sendTileToSwap = (tile: Tile) => {
     const copyRack = [...tilesInRack];
-    pullPlayTilesFromRack([tile], copyRack);
+    try {
+      pullPlayTilesFromRack([tile], copyRack);
+    } catch (err) {
+      console.log(err.message);
+      debugger;
+    }
     setTilesInRack(copyRack);
     setTilesToSwap([...tilesToSwap, tile]);
     return true;
@@ -31,7 +46,7 @@ const SwapTiles = ({
 
   const cleanup = () => {
     setTilesToSwap([]);
-    setTilesInRack(tileRack);
+    setTilesInRack(playerTiles);
   };
 
   const cancelSwap = () => {
@@ -72,7 +87,7 @@ const SwapTiles = ({
       <TileRack
         onTileClick={sendTileToSwap}
         tilesInRack={tilesInRack}
-        playerTiles={tileRack}
+        playerTiles={playerTiles}
       />
     </div>
   );

--- a/src/webapp/features/rabble/components/Theme.tsx
+++ b/src/webapp/features/rabble/components/Theme.tsx
@@ -5,7 +5,7 @@ const themes = {
     bg: "#3d3d29",
   },
   light: {
-    bg: "#FFE08122",
+    bg: "floralwhite",
     selection: "#FF957F",
     "selection-light": "#FF957F44",
     "selection-lighter": "#FF957F22",

--- a/src/webapp/features/rabble/components/TurnList.tsx
+++ b/src/webapp/features/rabble/components/TurnList.tsx
@@ -22,8 +22,8 @@ const TurnList = ({ turns, remainingTileCount }: TurnListProps) => (
           <th>Word</th>
           <th>Score</th>
         </tr>
-        {turns.map((t) => {
-          return <Turn key={t.turnID} turn={t} />;
+        {turns.map((t, idx) => {
+          return <Turn key={`${t.turnID}-${idx}`} turn={t} />;
         })}
       </tbody>
     </table>


### PR DESCRIPTION
 * Fixed a bug where swap tiles was causing the 'INVALID STATE ID' error by not waiting to end turn
 * Changed UX so that it's harder to accidentally swap tiles (now you pop a modal instead)
 * Style updates for the blank chooser modal as well (e.g. behind-modal overlay div)